### PR TITLE
docs(readme): mention default parser, cleanup copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 BSON is short for Bin­ary JSON and is the bin­ary-en­coded seri­al­iz­a­tion of JSON-like doc­u­ments. You can learn more about it in [the specification](http://bsonspec.org).
 
-This library is a native (C++) parser for Node.js that takes advantage of low-level bindings to be faster and use less memory than the default (but browser-friendly) JavaScript parser (located at [mongodb/js-bson](https://github.com/mongodb/js-bson)).
+This module is a C++ addon for Node.js that implements the BSON parsing and serialization outside of the JavaScript environment in order to increase speed and memory efficiency for certain workloads. It uses the same types as the pure JavaScript implementation, which can be found at [mongodb/js-bson](https://github.com/mongodb/js-bson).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # BSON parser
 
-If you don't yet know what BSON actually is, read [the spec](http://bsonspec.org).
+BSON is short for Bin­ary JSON and is the bin­ary-en­coded seri­al­iz­a­tion of JSON-like doc­u­ments. You can learn more about it in [the specification](http://bsonspec.org).
+
+This library is a native (C++) parser for Node.js that takes advantage of low-level bindings to be faster and use less memory than the default (but browser-friendly) JavaScript parser (located at [mongodb/js-bson](https://github.com/mongodb/js-bson)).
+
+## Usage
 
 To build a new version perform the following operation.
 
@@ -9,7 +13,7 @@ npm install
 npm run build
 ```
 
-A simple example of how to use BSON in `node.js`:
+A simple example of how to use BSON in `Node.js`:
 
 ```js
 // Get BSON parser class
@@ -41,58 +45,56 @@ console.log('doc_2:', doc_2)
 
 ### BSON types
 
-For all BSON types documentation, please refer to the documentation for the mongodb driver.
-
-https://github.com/mongodb/node-mongodb-native
+For all BSON types documentation, please refer to the documentation for the [MongoDB Node.js driver](https://github.com/mongodb/node-mongodb-native).
 
 ### BSON serialization and deserialiation
 
-**`new BSON()`** - Creates a new BSON seralizer/deserializer you can use to serialize and deserialize BSON.
+**`new BSON()`** - Creates a new BSON serializer/deserializer you can use to serialize and deserialize BSON.
 
 #### BSON.serialize
 
-The BSON serialize method takes a javascript object and an optional options object and returns a Node.js Buffer.
+The BSON `serialize` method takes a JavaScript object and an optional options object and returns a Node.js Buffer.
 
-  * BSON.serialize(object, options)
-    * @param {Object} object the Javascript object to serialize.
+  * `BSON.serialize(object, options)`
+    * @param {Object} object the JavaScript object to serialize.
     * @param {Boolean} [options.checkKeys=false] the serializer will check if keys are valid.
-    * @param {Boolean} [options.serializeFunctions=false] serialize the javascript. functions.
+    * @param {Boolean} [options.serializeFunctions=false] serialize the JavaScript. functions.
     * @param {Boolean} [options.ignoreUndefined=true]
     * @return {Buffer} returns a Buffer instance.
 
 #### BSON.serializeWithBufferAndIndex
 
-The BSON serializeWithBufferAndIndex method takes an object, a target buffer instance and an optional options object and returns the end serialization index in the final buffer.
+The BSON `serializeWithBufferAndIndex` method takes an object, a target buffer instance and an optional options object and returns the end serialization index in the final buffer.
 
-  * BSON.serializeWithBufferAndIndex(object, buffer, options)
-    * @param {Object} object the Javascript object to serialize.
+  * `BSON.serializeWithBufferAndIndex(object, buffer, options)`
+    * @param {Object} object the JavaScript object to serialize.
     * @param {Buffer} buffer the Buffer you pre-allocated to store the serialized BSON object.
     * @param {Boolean} [options.checkKeys=false] the serializer will check if keys are valid.
-    * @param {Boolean} [options.serializeFunctions=false] serialize the javascript functions.
+    * @param {Boolean} [options.serializeFunctions=false] serialize the JavaScript functions.
     * @param {Boolean} [options.ignoreUndefined=true] ignore undefined fields.
     * @param {Number} [options.index=0] the index in the buffer where we wish to start serializing into.
     * @return {Number} returns the index pointing to the last written byte in the buffer.
 
 #### BSON.calculateObjectSize
 
-The BSON calculateObjectSize method takes a javascript object and an optional options object and returns the size of the BSON object.
+The BSON `calculateObjectSize` method takes a JavaScript object and an optional options object and returns the size of the BSON object.
 
-  * BSON.calculateObjectSize(object, options)
-    * @param {Object} object the Javascript object to serialize.
-    * @param {Boolean} [options.serializeFunctions=false] serialize the javascript. functions.
+  * `BSON.calculateObjectSize(object, options)`
+    * @param {Object} object the JavaScript object to serialize.
+    * @param {Boolean} [options.serializeFunctions=false] serialize the JavaScript. functions.
     * @param {Boolean} [options.ignoreUndefined=true]
     * @return {Buffer} returns a Buffer instance.
 
 #### BSON.deserialize
 
-The BSON deserialize method takes a node.js Buffer and an optional options object and returns a deserialized Javascript object.
+The BSON `deserialize` method takes a Node.js Buffer and an optional options object and returns a deserialized JavaScript object.
 
-  * BSON.deserialize(buffer, options)
+  * `BSON.deserialize(buffer, options)`
     * @param {Object} [options.evalFunctions=false] evaluate functions in the BSON document scoped to the object deserialized.
     * @param {Object} [options.cacheFunctions=false] cache evaluated functions for reuse.
     * @param {Object} [options.cacheFunctionsCrc32=false] use a crc32 code for caching, otherwise use the string of the function.
     * @param {Object} [options.promoteLongs=true] when deserializing a Long will fit it into a Number if it's smaller than 53 bits
-    * @param {Object} [options.promoteBuffers=false] when deserializing a Binary will return it as a node.js Buffer instance.
+    * @param {Object} [options.promoteBuffers=false] when deserializing a Binary will return it as a Node.js Buffer instance.
     * @param {Object} [options.promoteValues=false] when deserializing will promote BSON values to their Node.js closest equivalent types.
     * @param {Object} [options.fieldsAsRaw=null] allow to specify if there what fields we wish to return as unserialized raw buffer.
     * @param {Object} [options.bsonRegExp=false] return BSON regular expressions as BSONRegExp instances.
@@ -100,9 +102,9 @@ The BSON deserialize method takes a node.js Buffer and an optional options objec
 
 #### BSON.deserializeStream
 
-The BSON deserializeStream method takes a node.js Buffer, startIndex and allow more control over deserialization of a Buffer containing concatenated BSON documents.
+The BSON `deserializeStream` method takes a Node.js Buffer, `startIndex` and allow more control over deserialization of a Buffer containing concatenated BSON documents.
 
-  * BSON.deserializeStream(buffer, startIndex, numberOfDocuments, documents, docStartIndex, options)
+  * `BSON.deserializeStream(buffer, startIndex, numberOfDocuments, documents, docStartIndex, options)`
     * @param {Buffer} buffer the buffer containing the serialized set of BSON documents.
     * @param {Number} startIndex the start index in the data Buffer where the deserialization is to start.
     * @param {Number} numberOfDocuments number of documents to deserialize.
@@ -112,8 +114,8 @@ The BSON deserializeStream method takes a node.js Buffer, startIndex and allow m
     * @param {Object} [options.cacheFunctions=false] cache evaluated functions for reuse.
     * @param {Object} [options.cacheFunctionsCrc32=false] use a crc32 code for caching, otherwise use the string of the function.
     * @param {Object} [options.promoteLongs=true] when deserializing a Long will fit it into a Number if it's smaller than 53 bits
-    * @param {Object} [options.promoteBuffers=false] when deserializing a Binary will return it as a node.js Buffer instance.
+    * @param {Object} [options.promoteBuffers=false] when deserializing a Binary will return it as a Node.js Buffer instance.
     * @param {Object} [options.promoteValues=false] when deserializing will promote BSON values to their Node.js closest equivalent types.
     * @param {Object} [options.fieldsAsRaw=null] allow to specify if there what fields we wish to return as unserialized raw buffer.
     * @param {Object} [options.bsonRegExp=false] return BSON regular expressions as BSONRegExp instances.
-    * @return {Object} returns the deserialized Javascript Object.
+    * @return {Object} returns the deserialized JavaScript Object.


### PR DESCRIPTION
This updates the readme to mention the native version of the parser as well as clean up the copy a bit 📖 

There is a related PR to the default parser: https://github.com/mongodb/js-bson/pull/230

NODE-995