### PR TITLE
feat(NODE-3302): replace MAX_BSON_SIZE with "maxBSONSize" property

### DIFF
--- a/src/bson.cc
+++ b/src/bson.cc
@@ -1272,7 +1272,7 @@ NAN_METHOD(BSON::New) {
   Nan::HandleScope scope;
 
   // Var maximum bson size
-  uint32_t maxBSONSize = MAX_BSON_SIZE;
+  uint32_t maxBSONSize = 17 * 1024 * 1024;
 
   // Check that we have an array
   if (info.Length() >= 1 && info[0]->IsArray()) {


### PR DESCRIPTION
## Description

- FEATURE: Got rid of the `MAX_BSON_SIZE` constant and only use `maxBSONSize` property to enable variable BSON size - fixes https://github.com/mongodb-js/bson-ext/issues/42
- BUGFIX: Replaced native exceptions with `ThrowAllocatedStringException()` so they can be correctly caught - fixes https://github.com/mongodb-js/bson-ext/issues/43

NODE-3302