### PR TITLE
perf(NODE-3570): short circuit check for keys that start with $

### DIFF
--- a/src/bson.cc
+++ b/src/bson.cc
@@ -756,7 +756,7 @@ Local<Value> BSONDeserializer::DeserializeDocument(bool raw) {
                                         promoteValues, fieldsAsRaw);
   // Serialize the document
   Local<Value> value = documentDeserializer.DeserializeDocumentInternal();
-  
+
   if (length != (p - start)) {
     ThrowAllocatedStringException(64, "Illegal Document Length");
   }
@@ -799,7 +799,7 @@ Local<Value> BSONDeserializer::DeserializeDocumentInternal() {
         }
       }
     }
-    
+
     // Deserialize the value
     const Local<Value> &value = DeserializeValue(type, raw);
     Nan::Set(returnObject, name, value);

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -754,11 +754,9 @@ Local<Value> BSONDeserializer::DeserializeDocument(bool raw) {
   BSONDeserializer documentDeserializer(*this, length - 4, bsonRegExp,
                                         promoteLongs, promoteBuffers,
                                         promoteValues, fieldsAsRaw);
-                                        
-
-  
   // Serialize the document
   Local<Value> value = documentDeserializer.DeserializeDocumentInternal();
+  
   if (length != (p - start)) {
     ThrowAllocatedStringException(64, "Illegal Document Length");
   }
@@ -801,6 +799,7 @@ Local<Value> BSONDeserializer::DeserializeDocumentInternal() {
         }
       }
     }
+    
     // Deserialize the value
     const Local<Value> &value = DeserializeValue(type, raw);
     Nan::Set(returnObject, name, value);


### PR DESCRIPTION
## Description

If no key starts with a $ - then there can be no $ref/$id/$db property. Looking for these is pretty inefficient currently.

Doing this results in about a 25% performance improvement (making it faster than JS where otherwise it would be slower).

All tests are passing

Turn off whitespace changes when reviewing - most of the change is just indenting the existing functionality into an if