### PR TITLE
fix(NODE-3619): serialization of BSON with embedded null bytes in strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ bson.sublime-workspace
 .vagrant/
 
 prebuilds/
+
+.vscode/

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -222,6 +222,8 @@ void BSONSerializer<T>::SerializeDocument(const Local<Value> &value) {
         this->CheckKey(propertyName);
       }
 
+      this->CheckForIllegalString(propertyName);
+
       propertyValue = NanGet(object, propertyName);
 
       // We are not serializing the function

--- a/test/node/null_byte_test.js
+++ b/test/node/null_byte_test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const expect = require('chai').expect;
+const BSONLib = require('../../lib/index');
+const createBSON = require('../utils');
+const BSON = Object.assign({}, BSONLib, Object.getPrototypeOf(createBSON()));
+
+describe('null byte handling in serializing', ()  => {
+    it('should throw when null byte in BSON Field name within a root document', () => {
+        expect(() => BSON.serialize({ 'a\x00b': 1 })).to.throw(/null bytes/);
+    });
+
+    it('should throw when null byte in BSON Field name within a sub-document', () => {
+        expect(() => BSON.serialize({ a: { 'a\x00b': 1 } })).to.throw(/null bytes/);
+    });
+
+    it('should throw when null byte in Pattern for a regular expression', () => {
+        // eslint-disable-next-line no-control-regex
+        expect(() => BSON.serialize({ a: new RegExp('a\x00b') })).to.throw(/null bytes/);
+        expect(() => BSON.serialize({ a: new BSON.BSONRegExp('a\x00b') })).to.throw(/null bytes/);
+    });
+
+    it('should throw when null byte in Flags/options for a regular expression', () => {
+        expect(() => BSON.serialize({ a: new BSON.BSONRegExp('a', 'i\x00m') })).to.throw(/regular expression option/);
+    });
+})

--- a/test/node/specs/bson-corpus/document.json
+++ b/test/node/specs/bson-corpus/document.json
@@ -31,6 +31,10 @@
         {
             "description": "Invalid subdocument: bad string length in field",
             "bson": "1C00000003666F6F001200000002626172000500000062617A000000"
+        },
+        {
+            "description": "Null byte in sub-document key",
+            "bson": "150000000378000D00000010610000010000000000"
         }
     ]
 }

--- a/test/node/specs/bson-corpus/regex.json
+++ b/test/node/specs/bson-corpus/regex.json
@@ -66,11 +66,11 @@
     ],
     "decodeErrors": [
         {
-            "description": "embedded null in pattern",
+            "description": "Null byte in pattern string",
             "bson": "0F0000000B610061006300696D0000"
         },
         {
-            "description": "embedded null in flags",
+            "description": "Null byte in flags string",
             "bson": "100000000B61006162630069006D0000"
         }
     ]

--- a/test/node/specs/bson-corpus/top.json
+++ b/test/node/specs/bson-corpus/top.json
@@ -69,29 +69,32 @@
         {
             "description": "Document truncated mid-key",
             "bson": "1200000002666F"
+        },
+        {
+            "description": "Null byte in document key",
+            "bson": "0D000000107800000100000000"
         }
     ],
     "parseErrors": [
         {
-            "description": "Bad $regularExpression (extra field)",
-            "string":
-                "{\"a\" : \"$regularExpression\": {\"pattern\": \"abc\", \"options\": \"\", \"unrelated\": true}}}"
+            "description" : "Bad $regularExpression (extra field)",
+            "string" : "{\"a\" : {\"$regularExpression\": {\"pattern\": \"abc\", \"options\": \"\", \"unrelated\": true}}}"
         },
         {
-            "description": "Bad $regularExpression (missing options field)",
-            "string": "{\"a\" : \"$regularExpression\": {\"pattern\": \"abc\"}}}"
+            "description" : "Bad $regularExpression (missing options field)",
+            "string" : "{\"a\" : {\"$regularExpression\": {\"pattern\": \"abc\"}}}"
         },
         {
             "description": "Bad $regularExpression (pattern is number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"$options\" : \"\"}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": 42, \"options\" : \"\"}}}"
         },
         {
             "description": "Bad $regularExpression (options are number, not string)",
-            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"$options\" : 0}}}"
+            "string": "{\"x\" : {\"$regularExpression\" : { \"pattern\": \"a\", \"options\" : 0}}}"
         },
         {
-            "description": "Bad $regularExpression (missing pattern field)",
-            "string": "{\"a\" : \"$regularExpression\": {\"options\":\"ix\"}}}"
+            "description" : "Bad $regularExpression (missing pattern field)",
+            "string" : "{\"a\" : {\"$regularExpression\": {\"options\":\"ix\"}}}"
         },
         {
             "description": "Bad $oid (number, not string)",
@@ -151,12 +154,15 @@
         },
         {
             "description": "Bad $binary (extra field)",
-            "string":
-                "{\"x\" : {\"$binary\" : {\"base64\" : \"//8=\", \"subType\" : 0, \"unrelated\": true}}}"
+            "string": "{\"x\" : {\"$binary\" : {\"base64\" : \"//8=\", \"subType\" : 0, \"unrelated\": true}}}"
         },
         {
             "description": "Bad $code (type is number, not string)",
             "string": "{\"a\" : {\"$code\" : 42}}"
+        },
+        {
+            "description": "Bad $code (type is number, not string) when $scope is also present",
+            "string": "{\"a\" : {\"$code\" : 42, \"$scope\" : {}}}"
         },
         {
             "description": "Bad $code (extra field)",
@@ -180,13 +186,11 @@
         },
         {
             "description": "Bad $timestamp (extra field at same level as $timestamp)",
-            "string":
-                "{\"a\" : {\"$timestamp\" : {\"t\" : \"123456789\", \"i\" : \"42\"}, \"unrelated\": true } }"
+            "string": "{\"a\" : {\"$timestamp\" : {\"t\" : \"123456789\", \"i\" : \"42\"}, \"unrelated\": true } }"
         },
         {
             "description": "Bad $timestamp (extra field at same level as t and i)",
-            "string":
-                "{\"a\" : {\"$timestamp\" : {\"t\" : \"123456789\", \"i\" : \"42\", \"unrelated\": true} } }"
+            "string": "{\"a\" : {\"$timestamp\" : {\"t\" : \"123456789\", \"i\" : \"42\", \"unrelated\": true} } }"
         },
         {
             "description": "Bad $timestamp (missing t)",
@@ -202,16 +206,7 @@
         },
         {
             "description": "Bad $date (extra field)",
-            "string":
-                "{\"a\" : {\"$date\" : {\"$numberLong\" : \"1356351330501\"}, \"unrelated\": true}}"
-        },
-        {
-            "description": "Bad DBRef (ref is number, not string)",
-            "string": "{\"x\" : {\"$ref\" : 42, \"$id\" : \"abc\"}}"
-        },
-        {
-            "description": "Bad DBRef (db is number, not string)",
-            "string": "{\"x\" : {\"$ref\" : \"a\", \"$id\" : \"abc\", \"$db\" : 42}}"
+            "string": "{\"a\" : {\"$date\" : {\"$numberLong\" : \"1356351330501\"}, \"unrelated\": true}}"
         },
         {
             "description": "Bad $minKey (boolean, not integer)",
@@ -239,8 +234,23 @@
         },
         {
             "description": "Bad DBpointer (extra field)",
-            "string":
-                "{\"a\": {\"$dbPointer\": {\"a\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"56e1fc72e0c917e9c4714161\"}, \"c\": {\"$numberInt\": \"2\"}, \"$ref\": \"b\"}}}"
+            "string": "{\"a\": {\"$dbPointer\": {\"a\": {\"$numberInt\": \"1\"}, \"$id\": {\"$oid\": \"56e1fc72e0c917e9c4714161\"}, \"c\": {\"$numberInt\": \"2\"}, \"$ref\": \"b\"}}}"
+        },
+        {
+            "description" : "Null byte in document key",
+            "string" : "{\"a\\u0000\": 1 }"
+        },
+        {
+            "description" : "Null byte in sub-document key",
+            "string" : "{\"a\" : {\"b\\u0000\": 1 }}"
+        },
+        {
+            "description": "Null byte in $regularExpression pattern",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\\u0000\", \"options\" : \"i\"}}}"
+        },
+        {
+            "description": "Null byte in $regularExpression options",
+            "string": "{\"a\" : {\"$regularExpression\" : { \"pattern\": \"b\", \"options\" : \"i\\u0000\"}}}"
         }
     ]
 }


### PR DESCRIPTION
We are not asserting that keys cannot contain null in this library currently, proposed a fix along with sync-ed tests.