### PR TITLE
fix(NODE-4532): round trip double values consistently

### DIFF
--- a/.evergreen/install-dependencies.sh
+++ b/.evergreen/install-dependencies.sh
@@ -11,8 +11,8 @@ NODE_ARTIFACTS_PATH="${PROJECT_DIRECTORY}/node-artifacts"
 NPM_CACHE_DIR="${NODE_ARTIFACTS_PATH}/npm"
 NPM_TMP_DIR="${NODE_ARTIFACTS_PATH}/tmp"
 
-NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.7/nvm-noinstall.zip"
-NVM_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh"
+NVM_WINDOWS_URL="https://github.com/coreybutler/nvm-windows/releases/download/1.1.9/nvm-noinstall.zip"
+NVM_URL="https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh"
 
 # this needs to be explicitly exported for the nvm install below
 export NVM_DIR="${NODE_ARTIFACTS_PATH}/nvm"

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -338,7 +338,7 @@ void BSONSerializer<T>::SerializeValue(void *typeLocation,
   if (value->IsNumber()) {
     double doubleValue = NanTo<double>(value);
     double flooredValue = floor(doubleValue);
-    bool isNegativeZero = signbit(doubleValue) == 1 && std::fpclassify(doubleValue) == FP_ZERO;
+    bool isNegativeZero = std::signbit(doubleValue) == true && std::fpclassify(doubleValue) == FP_ZERO;
 
     if (isNegativeZero) {
       // TODO(NODE-4335): -0 should be serialized as double

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -337,11 +337,14 @@ void BSONSerializer<T>::SerializeValue(void *typeLocation,
   // Process all the values
   if (value->IsNumber()) {
     double doubleValue = NanTo<double>(value);
-    int intValue = (int)doubleValue;
-    if (intValue == doubleValue) {
+    double flooredValue = floor(doubleValue);
+    if (flooredValue == doubleValue && flooredValue <= INT32_MAX && flooredValue >= INT32_MIN) {
+      // If there is no fractional component and we are within an [int32.min, int32.max]
+      // write a bson int32
       this->CommitType(typeLocation, BSON_TYPE_INT);
-      this->WriteInt32(intValue);
+      this->WriteInt32(flooredValue);
     } else {
+      // otherwise write the double
       this->CommitType(typeLocation, BSON_TYPE_NUMBER);
       this->WriteDouble(doubleValue);
     }

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -337,7 +337,7 @@ void BSONSerializer<T>::SerializeValue(void *typeLocation,
   // Process all the values
   if (value->IsNumber()) {
     double doubleValue = NanTo<double>(value);
-    double flooredValue = floor(doubleValue);
+    double flooredValue = std::floor(doubleValue);
     bool isNegativeZero = std::signbit(doubleValue) == true && std::fpclassify(doubleValue) == FP_ZERO;
 
     if (isNegativeZero) {

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1171,7 +1171,7 @@ describe('BSON', function() {
       var doc = { doc: val };
       var serialized_data = createBSON().serialize(doc);
 
-      var serialized_data2 = new Buffer.alloc(createBSON().calculateObjectSize(doc));
+      var serialized_data2 = new Buffer(createBSON().calculateObjectSize(doc));
       createBSON().serializeWithBufferAndIndex(doc, serialized_data2);
       assertBuffersEqual(done, serialized_data, serialized_data2, 0);
 

--- a/test/node/bson_test.js
+++ b/test/node/bson_test.js
@@ -1171,7 +1171,7 @@ describe('BSON', function() {
       var doc = { doc: val };
       var serialized_data = createBSON().serialize(doc);
 
-      var serialized_data2 = new Buffer(createBSON().calculateObjectSize(doc));
+      var serialized_data2 = new Buffer.alloc(createBSON().calculateObjectSize(doc));
       createBSON().serializeWithBufferAndIndex(doc, serialized_data2);
       assertBuffersEqual(done, serialized_data, serialized_data2, 0);
 

--- a/test/node/number_test.js
+++ b/test/node/number_test.js
@@ -1,8 +1,8 @@
-'use strict';
+"use strict";
 
-const expect = require('chai').expect;
+const expect = require("chai").expect;
 
-const BSON = require('../..');
+const BSON = require("../..");
 
 const BSON_DOUBLE_TYPE = 0x01;
 const BSON_INT32_TYPE = 0x10;
@@ -10,7 +10,7 @@ const BSON_INT32_TYPE = 0x10;
 const INT32_MAX = 2147483647;
 const INT32_MIN = -2147483648;
 
-const nanPayloadBuffer = Buffer.from('120000000000F87F', 'hex');
+const nanPayloadBuffer = Buffer.from("120000000000F87F", "hex");
 const nanPayloadDV = new DataView(
   nanPayloadBuffer.buffer,
   nanPayloadBuffer.byteOffset,
@@ -18,8 +18,8 @@ const nanPayloadDV = new DataView(
 );
 const nanPayloadDouble = nanPayloadDV.getFloat64(0, true);
 
-describe('serializing javascript numbers', () => {
-  it('should serialize a number that exceeds int32.max as a double', () => {
+describe("serializing javascript numbers", () => {
+  it("should serialize a number that exceeds int32.max as a double", () => {
     const document = { a: INT32_MAX + 1 };
     const bytes = BSON.serialize(document);
 
@@ -29,7 +29,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should serialize a number that negatively exceeds int32.min as a double', () => {
+  it("should serialize a number that negatively exceeds int32.min as a double", () => {
     const document = { a: INT32_MIN - 1 };
     const bytes = BSON.serialize(document);
 
@@ -39,7 +39,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should serialize a number that is exactly int32.max as int32', () => {
+  it("should serialize a number that is exactly int32.max as int32", () => {
     const document = { a: INT32_MAX };
     const bytes = BSON.serialize(document);
 
@@ -49,7 +49,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should serialize a number that is exactly int32.min as int32', () => {
+  it("should serialize a number that is exactly int32.min as int32", () => {
     const document = { a: INT32_MIN };
     const bytes = BSON.serialize(document);
 
@@ -59,7 +59,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should serialize a number that has a fractional component as double', () => {
+  it("should serialize a number that has a fractional component as double", () => {
     const document = { a: 2.3 };
     const bytes = BSON.serialize(document);
 
@@ -69,7 +69,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it.skip('should preserve -0.0 through round trip -- TODO(NODE-4335)', () => {
+  it.skip("should preserve -0.0 through round trip -- TODO(NODE-4335)", () => {
     // TODO(NODE-4335): -0 should be serialized as double
     const document = { a: -0.0 };
     const bytes = BSON.serialize(document);
@@ -81,7 +81,19 @@ describe('serializing javascript numbers', () => {
     expect(Object.is(returnedDocument.a, -0.0)).to.be.true;
   });
 
-  it('converts -0.0 to an int32 -- TODO(NODE-4335)', () => {
+  it("should preserve Double(-0.0) through round trip -- TODO(NODE-4335)", () => {
+    // TODO(NODE-4335): -0 should be serialized as double
+    const document = { a: new BSON.Double(-0.0) };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes, { promoteValues: false });
+    expect(returnedDocument).to.deep.equal(document);
+    expect(Object.is(returnedDocument.a.valueOf(), -0.0)).to.be.true;
+  });
+
+  it("converts -0.0 to an int32 -- TODO(NODE-4335)", () => {
     // TODO(NODE-4335): -0 should be serialized as double
     // This test is demonstrating the behavior of -0 being serialized as an int32 something we do NOT want to unintentionally change, but may want to change in the future, which the above ticket serves to track.
     const document = { a: -0.0 };
@@ -90,11 +102,11 @@ describe('serializing javascript numbers', () => {
     expect(bytes[4]).to.equal(BSON_INT32_TYPE);
 
     const returnedDocument = BSON.deserialize(bytes);
-    expect(returnedDocument).to.have.property('a', 0);
+    expect(returnedDocument).to.have.property("a", 0);
     expect(Object.is(returnedDocument.a, -0.0)).to.be.false;
   });
 
-  it('should preserve NaN through round trip', () => {
+  it("should preserve NaN through round trip", () => {
     const document = { a: NaN };
     const bytes = BSON.serialize(document);
 
@@ -104,7 +116,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should preserve NaN with payload through round trip', () => {
+  it("should preserve NaN with payload through round trip", () => {
     const document = { a: nanPayloadDouble };
     const bytes = BSON.serialize(document);
 
@@ -115,7 +127,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should preserve Infinity through round trip', () => {
+  it("should preserve Infinity through round trip", () => {
     const document = { a: Infinity };
     const bytes = BSON.serialize(document);
 
@@ -125,7 +137,7 @@ describe('serializing javascript numbers', () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it('should preserve -Infinity through round trip', () => {
+  it("should preserve -Infinity through round trip", () => {
     const document = { a: -Infinity };
     const bytes = BSON.serialize(document);
 

--- a/test/node/number_test.js
+++ b/test/node/number_test.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 
-const expect = require("chai").expect;
+const expect = require('chai').expect;
 
-const BSON = require("../..");
+const BSON = require('../..');
 
 const BSON_DOUBLE_TYPE = 0x01;
 const BSON_INT32_TYPE = 0x10;
@@ -10,7 +10,7 @@ const BSON_INT32_TYPE = 0x10;
 const INT32_MAX = 2147483647;
 const INT32_MIN = -2147483648;
 
-const nanPayloadBuffer = Buffer.from("120000000000F87F", "hex");
+const nanPayloadBuffer = Buffer.from('120000000000F87F', 'hex');
 const nanPayloadDV = new DataView(
   nanPayloadBuffer.buffer,
   nanPayloadBuffer.byteOffset,
@@ -18,8 +18,8 @@ const nanPayloadDV = new DataView(
 );
 const nanPayloadDouble = nanPayloadDV.getFloat64(0, true);
 
-describe("serializing javascript numbers", () => {
-  it("should serialize a number that exceeds int32.max as a double", () => {
+describe('serializing javascript numbers', () => {
+  it('serialize a number that exceeds int32.max as a double', () => {
     const document = { a: INT32_MAX + 1 };
     const bytes = BSON.serialize(document);
 
@@ -29,7 +29,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should serialize a number that negatively exceeds int32.min as a double", () => {
+  it('serialize a number that negatively exceeds int32.min as a double', () => {
     const document = { a: INT32_MIN - 1 };
     const bytes = BSON.serialize(document);
 
@@ -39,7 +39,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should serialize a number that is exactly int32.max as int32", () => {
+  it('serialize a number that is exactly int32.max as int32', () => {
     const document = { a: INT32_MAX };
     const bytes = BSON.serialize(document);
 
@@ -49,7 +49,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should serialize a number that is exactly int32.min as int32", () => {
+  it('serialize a number that is exactly int32.min as int32', () => {
     const document = { a: INT32_MIN };
     const bytes = BSON.serialize(document);
 
@@ -59,7 +59,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should serialize a number that has a fractional component as double", () => {
+  it('serialize a number that has a fractional component as double', () => {
     const document = { a: 2.3 };
     const bytes = BSON.serialize(document);
 
@@ -69,8 +69,8 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it.skip("should preserve -0.0 through round trip -- TODO(NODE-4335)", () => {
-    // TODO(NODE-4335): -0 should be serialized as double
+  it.skip('preserve -0.0 through round trip -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 be serialized as double
     const document = { a: -0.0 };
     const bytes = BSON.serialize(document);
 
@@ -81,8 +81,8 @@ describe("serializing javascript numbers", () => {
     expect(Object.is(returnedDocument.a, -0.0)).to.be.true;
   });
 
-  it("should preserve Double(-0.0) through round trip -- TODO(NODE-4335)", () => {
-    // TODO(NODE-4335): -0 should be serialized as double
+  it('preserve Double(-0.0) through round trip -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 be serialized as double
     const document = { a: new BSON.Double(-0.0) };
     const bytes = BSON.serialize(document);
 
@@ -93,8 +93,8 @@ describe("serializing javascript numbers", () => {
     expect(Object.is(returnedDocument.a.valueOf(), -0.0)).to.be.true;
   });
 
-  it("converts -0.0 to an int32 -- TODO(NODE-4335)", () => {
-    // TODO(NODE-4335): -0 should be serialized as double
+  it('converts -0.0 to an int32 -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 be serialized as double
     // This test is demonstrating the behavior of -0 being serialized as an int32 something we do NOT want to unintentionally change, but may want to change in the future, which the above ticket serves to track.
     const document = { a: -0.0 };
     const bytes = BSON.serialize(document);
@@ -102,11 +102,11 @@ describe("serializing javascript numbers", () => {
     expect(bytes[4]).to.equal(BSON_INT32_TYPE);
 
     const returnedDocument = BSON.deserialize(bytes);
-    expect(returnedDocument).to.have.property("a", 0);
+    expect(returnedDocument).to.have.property('a', 0);
     expect(Object.is(returnedDocument.a, -0.0)).to.be.false;
   });
 
-  it("should preserve NaN through round trip", () => {
+  it('preserve NaN through round trip', () => {
     const document = { a: NaN };
     const bytes = BSON.serialize(document);
 
@@ -116,7 +116,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should preserve NaN with payload through round trip", () => {
+  it('preserve NaN with payload through round trip', () => {
     const document = { a: nanPayloadDouble };
     const bytes = BSON.serialize(document);
 
@@ -127,7 +127,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should preserve Infinity through round trip", () => {
+  it('preserve Infinity through round trip', () => {
     const document = { a: Infinity };
     const bytes = BSON.serialize(document);
 
@@ -137,7 +137,7 @@ describe("serializing javascript numbers", () => {
     expect(returnedDocument).to.deep.equal(document);
   });
 
-  it("should preserve -Infinity through round trip", () => {
+  it('preserve -Infinity through round trip', () => {
     const document = { a: -Infinity };
     const bytes = BSON.serialize(document);
 

--- a/test/node/number_test.js
+++ b/test/node/number_test.js
@@ -10,6 +10,14 @@ const BSON_INT32_TYPE = 0x10;
 const INT32_MAX = 2147483647;
 const INT32_MIN = -2147483648;
 
+const nanPayloadBuffer = Buffer.from('120000000000F87F', 'hex');
+const nanPayloadDV = new DataView(
+  nanPayloadBuffer.buffer,
+  nanPayloadBuffer.byteOffset,
+  nanPayloadBuffer.byteLength
+);
+const nanPayloadDouble = nanPayloadDV.getFloat64(0, true);
+
 describe('serializing javascript numbers', () => {
   it('should serialize a number that exceeds int32.max as a double', () => {
     const document = { a: INT32_MAX + 1 };
@@ -53,6 +61,72 @@ describe('serializing javascript numbers', () => {
 
   it('should serialize a number that has a fractional component as double', () => {
     const document = { a: 2.3 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it.skip('should preserve -0.0 through round trip -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 should be serialized as double
+    const document = { a: -0.0 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+    expect(Object.is(returnedDocument.a, -0.0)).to.be.true;
+  });
+
+  it('converts -0.0 to an int32 -- TODO(NODE-4335)', () => {
+    // TODO(NODE-4335): -0 should be serialized as double
+    // This test is demonstrating the behavior of -0 being serialized as an int32 something we do NOT want to unintentionally change, but may want to change in the future, which the above ticket serves to track.
+    const document = { a: -0.0 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_INT32_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.have.property('a', 0);
+    expect(Object.is(returnedDocument.a, -0.0)).to.be.false;
+  });
+
+  it('should preserve NaN through round trip', () => {
+    const document = { a: NaN };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should preserve NaN with payload through round trip', () => {
+    const document = { a: nanPayloadDouble };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+    expect(bytes.subarray(7, 15)).to.deep.equal(nanPayloadBuffer);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should preserve Infinity through round trip', () => {
+    const document = { a: Infinity };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should preserve -Infinity through round trip', () => {
+    const document = { a: -Infinity };
     const bytes = BSON.serialize(document);
 
     expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);

--- a/test/node/number_test.js
+++ b/test/node/number_test.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const BSON = require('../..');
+
+const BSON_DOUBLE_TYPE = 0x01;
+const BSON_INT32_TYPE = 0x10;
+
+const INT32_MAX = 2147483647;
+const INT32_MIN = -2147483648;
+
+describe('serializing javascript numbers', () => {
+  it('should serialize a number that exceeds int32.max as a double', () => {
+    const document = { a: INT32_MAX + 1 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should serialize a number that negatively exceeds int32.min as a double', () => {
+    const document = { a: INT32_MIN - 1 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should serialize a number that is exactly int32.max as int32', () => {
+    const document = { a: INT32_MAX };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_INT32_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should serialize a number that is exactly int32.min as int32', () => {
+    const document = { a: INT32_MIN };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_INT32_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+
+  it('should serialize a number that has a fractional component as double', () => {
+    const document = { a: 2.3 };
+    const bytes = BSON.serialize(document);
+
+    expect(bytes[4]).to.equal(BSON_DOUBLE_TYPE);
+
+    const returnedDocument = BSON.deserialize(bytes);
+    expect(returnedDocument).to.deep.equal(document);
+  });
+});


### PR DESCRIPTION
## Description

**What changed?**

Instead of relying on casting to convert our double I changed the code to use math.h or cmath's floor function. 
